### PR TITLE
Migrate from framer-motion to motion package

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ async function checkNpmInstalled() {
         { title: 'Axios', value: 'axios' },
         { title: 'Redux Toolkit', value: '@reduxjs/toolkit' },
         { title: 'React Query', value: 'react-query' },
-        { title: 'Framer Motion', value: 'framer-motion' },
+        { title: 'Motion (prev Framer Motion)', value: 'motion' },
         { title: 'React Hook Form', value: 'react-hook-form' },
       ],
     },
@@ -216,9 +216,9 @@ async function checkNpmInstalled() {
       await runCommand('npm', ['install', ...additionalPackages]);
     }
 
-    if (additionalFeatures.includes('animations') && !additionalPackages.includes('framer-motion')) {
-      console.log(chalk.blue('\nInstalling Framer Motion for animations...\n'));
-      await runCommand('npm', ['install', 'framer-motion']);
+    if (additionalFeatures.includes('animations') && !additionalPackages.includes('motion')) {
+      console.log(chalk.blue('\nInstalling Motion (prev Framer Motion) for animations...\n'));
+      await runCommand('npm', ['install', 'motion']);
     }
 
     if (additionalFeatures.includes('form') && !additionalPackages.includes('react-hook-form')) {
@@ -576,7 +576,7 @@ async function updateMainApp(additionalFeatures, iconSet) {
 import { Layout } from './components/Layout';
 ${additionalFeatures.includes('darkMode') ? "import { ThemeProvider } from './components/ThemeProvider';" : ''}
 ${additionalFeatures.includes('form') ? "import SampleForm from './components/SampleForm';" : ''}
-${additionalFeatures.includes('animations') ? "import { motion } from 'framer-motion';" : ''}
+${additionalFeatures.includes('animations') ? "import { motion } from 'motion';" : ''}
 
 function App() {
   return (


### PR DESCRIPTION
Framer Motion has been rebranded to Motion (https://motion.dev/). 

This PR updates our installer to use the new motion package name instead of the legacy framer-motion name.

Changes
Updated package name from framer-motion to motion in the installer
Updated related comments and documentation

Why this change?
Future Compatibility: The motion package is now the official package name going forward
Smaller Bundle Size: The new package is more optimized and has a smaller footprint
Better Developer Experience: Aligns with the latest documentation and community standards